### PR TITLE
Adding support for CSP-compliant js sources.

### DIFF
--- a/lib/dart_to_js_script_rewriter.dart
+++ b/lib/dart_to_js_script_rewriter.dart
@@ -12,10 +12,12 @@ import 'dart:async' show Future;
 /// speeds up initial loads. Win!
 class DartToJsScriptRewriter extends Transformer {
   bool releaseMode = false;
+  bool csp;
   
   DartToJsScriptRewriter.asPlugin(BarbackSettings settings)
-      : releaseMode = (settings.mode == BarbackMode.RELEASE);
-  
+      : releaseMode = (settings.mode == BarbackMode.RELEASE),
+        csp = (settings.configuration["csp"] == true);
+
   String get allowedExtensions => ".html";
   
   Future apply(Transform transform) {
@@ -47,7 +49,7 @@ class DartToJsScriptRewriter extends Transformer {
              tag.attributes['src'] != null;
     }).forEach((tag) {
       var src = tag.attributes['src'];
-      tag.attributes['src'] = '$src.js';
+      tag.attributes['src'] = src + (csp ? '.precompiled.js' : '.js');
       tag.attributes.remove('type');
     });
   }


### PR DESCRIPTION
Adding support for packaged apps (e.g. Chrome Apps, Firefox OS _privileged_ [1] apps) and general CSP-enabled  web apps.

To enable this feature -- which rewrites Dart source imports to `source.precompiled.js` -- just add this to _pubspec.yaml_:

```
transformers:
- dart_to_js_script_rewriter:
    csp: true
```

[1] https://developer.mozilla.org/en-US/Marketplace/Publishing/Packaged_apps#Types_of_packaged_apps
