### PR TITLE
Prevent removal of other *.dart.js script tags

### DIFF
--- a/lib/dart_to_js_script_rewriter.dart
+++ b/lib/dart_to_js_script_rewriter.dart
@@ -37,7 +37,7 @@ class DartToJsScriptRewriter extends Transformer {
   void removeDartDotJsTags(Document document) {
     document.querySelectorAll('script').where((tag) {
       return tag.attributes['src'] != null &&
-          tag.attributes['src'].endsWith('dart.js');
+          tag.attributes['src'].endsWith('browser/dart.js');
     }).forEach((tag) => tag.remove());
   }
 


### PR DESCRIPTION
The following script tag is incorrectly removed by the transformer:

```html
<script src="/js/test.dart.js" type="text/javascript"></script>
```

This PR will more specifically target the `dart.js` provided by the `browser` package.

@sethladd 