### PR TITLE
Remove deprecated authors field from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,14 +2,6 @@ name: dart_to_js_script_rewriter
 description: Replaces Dart script tags with JavaScript script tags,
              speeding up initial loads and reducing 404s. Use when
              ready to deploy.
-authors:
-  - Seth Ladd <sethladd@gmail.com>
-  - Workiva Client Platform Team <clientplatform@workiva.com>
-  - Dustin Lessard <dustin.lessard@workiva.com>
-  - Evan Weible <evan.weible@workiva.com>
-  - Jay Udey <jay.udey@workiva.com>
-  - Max Peterson <maxwell.peterson@workiva.com>
-  - Trent Grover <trent.grover@workiva.com>
 version: 1.0.3
 homepage: https://github.com/Workiva/dart_to_js_script_rewriter
 environment:


### PR DESCRIPTION
This PR removes the author field from any `pubspec.yaml` files in this repo,
as the field was deprecated in Dart 2.7 and is no longer needed.

Removing this field will silence the warning that `pub publish` emits, which
has the added benefit of allowing us to use `pub publish --dry-run` as a
quality check during CI.

If you'd like to retain the author information, we recommend adding an
`AUTHORS.md` file in the repo or the package directory.

---

This PR was created automatically from a Sourcegraph batch change.
Please reach out to @evanweible-wf or #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_pubspec_authors`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_pubspec_authors)