### PR TITLE
DE-715: Delete docs.yaml file for Workiva/dart_to_js_script_rewriter

### DIFF
--- a/docs.yml
+++ b/docs.yml
@@ -1,3 +1,0 @@
-title: dart_to_js_script_rewriter
-base: github:Workiva/dart_to_js_script_rewriter/
-src: README.md


### PR DESCRIPTION
### JIRA Ticket
https://jira.atl.workiva.net/browse/DE-715

### Problem / Feature
As part of, [Dev Portal Service deprecation](https://wiki.atl.workiva.net/display/DE/Poster+-+Dev+Portal+Discovery+2.0%3A+Discovery+and+Planning); removing the “docs.yml” file that’s been created to render repo docs on to the portal.

### Solution / Approach
 File paths included in `docs.yaml `of this repo will no longer be rendered/hosted on [Dev Portal](https://dev.workiva.net/docs/teams/platform/application-frameworks/libraries/dart_to_js_script_rewriter) with the yaml file deletion.
