### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/example/test.dart
+++ b/example/test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:html';
 
 void main() {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 library dart_to_js_script_rewriter.test.integration_test;
 

--- a/test/unit_test.dart
+++ b/test/unit_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 library dart_to_js_script_rewriter.test.unit_test;
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 library dart_to_js_script_rewriter.tool.dev;
 
 import 'package:dart_dev/dart_dev.dart' show dev, config;


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)